### PR TITLE
fix: cast environment variable to int

### DIFF
--- a/ckan/lib/uploader.py
+++ b/ckan/lib/uploader.py
@@ -93,7 +93,7 @@ def get_max_image_size() -> int:
 
 
 def get_max_resource_size() -> int:
-    return config.get('ckan.max_resource_size')
+    return int(config.get('ckan.max_resource_size') or 10)
 
 
 class Upload(object):


### PR DESCRIPTION
By casting that environment variable as int it can be ensured that values read from ckanext-envvars will be read and used correctly

Fixes #

Otherwise it threw this exception for me:

 2023-08-03 13:59:34,452 ERROR [ckan.config.middleware.flask_app] '>' not supported between instances of 'int' and 'str'
 Traceback (most recent call last):
   File "/usr/lib/python3.10/site-packages/flask/app.py", line 1516, in full_dispatch_request
     rv = self.dispatch_request()
   File "/usr/lib/python3.10/site-packages/flask/app.py", line 1502, in dispatch_request
     return self.ensure_sync(self.view_functions[rule.endpoint])(**req.view_args)
   File "/usr/lib/python3.10/site-packages/flask/views.py", line 84, in view
     return current_app.ensure_sync(self.dispatch_request)(*args, **kwargs)
   File "/usr/lib/python3.10/site-packages/flask/views.py", line 158, in dispatch_request
     return current_app.ensure_sync(meth)(*args, **kwargs)
   File "/srv/app/src/ckan/ckan/config/middleware/../../views/resource.py", line 253, in post
     get_action(u'resource_create')(context, data)
   File "/srv/app/src/ckan/ckan/logic/__init__.py", line 551, in wrapped
     result = _action(context, data_dict, **kw)
   File "/srv/app/src/ckan/ckan/logic/action/create.py", line 342, in resource_create
     upload.upload(package.resources[-1].id,
   File "/srv/app/src/ckan/ckan/lib/uploader.py", line 338, in upload
     _copy_file(self.upload_file, output_file, max_size)
   File "/srv/app/src/ckan/ckan/lib/uploader.py", line 39, in _copy_file
     if current_size > max_size:
 TypeError: '>' not supported between instances of 'int' and 'str'


### Proposed fixes:



### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
